### PR TITLE
Corrected kinetic energy evaluation

### DIFF
--- a/code/config.py
+++ b/code/config.py
@@ -6,16 +6,19 @@ class opt_parameters:
 
 
         ### initialize random starting G ###
-        self.G = np.random.uniform(-1, 1, size=(2 * self.N_sites, 2 * self.N_sites)) + \
-          1.0j * np.random.uniform(-1, 1, size=(2 * self.N_sites, 2 * self.N_sites))
-        self.G = self.G + self.G.conj().T
+        self.G = np.random.uniform(-1, 1, size = (2 * self.N_sites, 2 * self.N_sites))
+        q, r = np.linalg.qr(self.G)
+
+        d = np.eye((2 * self.N_sites))
+        d[0, 0] = 0.
+        d[self.N_sites, self.N_sites] = 0.
+        self.G = np.linalg.inv(q) @ d @ q
 
         ### initialize random starting Omega ###
         self.O = np.random.uniform(-1, 1, size=(2 * self.N_sites, 2 * self.N_sites)) / 10.
         self.O = self.O + self.O.T
 
         self.O[np.arange(2 * self.N_sites), np.arange(2 * self.N_sites)] = 0.
-
 
 
         ### nearest-neighbor hopping with PBC ###

--- a/code/varstate.py
+++ b/code/varstate.py
@@ -14,7 +14,7 @@ class VarState:
     def energy(self):
         S = self.nsites  # just for brevity
 
-        alpha = -np.subtract.outer(self.O, self.O)
+        alpha = np.subtract.outer(self.O, self.O)
         alpha = np.diagonal(alpha.transpose((2, 0, 1, 3)), axis1=-1, axis2=-2)
 
         Aexp = np.zeros((2 * S, 2 * S, 2 * S, 2 * S), dtype=np.complex128)
@@ -30,7 +30,7 @@ class VarState:
 
         Phis = Aexp @ d4_Gamma @ np.linalg.inv(d4_id - (d4_id - Aexp) @ d4_Gamma)
         Phis = np.diagonal(Phis.transpose((0, 2, 1, 3)), axis1=0, axis2=1)
-        Phis = np.diagonal(Phis, axis1=0, axis2=1).T  # abpq -> ab
+        Phis = np.diagonal(Phis, axis1=0, axis2=1)  # abpq -> ab
 
 
         exp_small = np.diagonal(Aexp.conj(), axis1=-1, axis2=-2)


### PR DESCRIPTION
## Change 1.
`A[i, j] = 2(Omega[j, :] - Omega[i, :])` by definition.  If `M = np.subtract.outer(Omega, Omega)`:
- If we do `.transpose(2, 0, 1, 3)` and then apply `.diagonal(...)` over the last two axis, indices transform as following:
 `ijkl -> kijl -> kij (l = j)`
- Then, a new element `A[a, b, c]` corresponds to the original `M[b, c, a, c]`, which is exactly what we need. Thus, we don't need minus when computing `M`

## Change 2.
Unnecessary transpose in `Phis`. Indices transform as following:
- Original indices: `ijkl`
- After `transpose(0, 2, 1, 3)`: `ikjl`
- After `diagonal(0, 1)`: `jli (k = i)`
- After `diagonal(0, 1)` : `ij (k = i, l = j)`

Thus, without the last `.T` operation, element `Phis[a, b]` corresponds to `PhisOriginal[a, b, a, b]`, which is what we need.

## Change 3.
Corrected G matrix initialization such that the matrix is idempotent.